### PR TITLE
fix .desktop support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,16 @@ docker pull mundialis/docker-qgis2
 
 
 You can download a convenient "qgis2" startup script here: [qgis2](https://raw.githubusercontent.com/mundialis/docker-qgis2/master/qgis2).
-
 Download the file and store it either into `$HOME/bin/` or in `/usr/local/bin/` (or likewise into a directory listed in your PATH environment variable) and set the "executable" flag of the script.
 Hence, be sure to make the "qgis2" script an executable:
 ```
 chmod a+x qgis2
+```
+
+A .desktop file can be used as well for starting QGIS from a desktop environment.
+Modify the paths to the qgis2 launch script and the icon inside `qgis.desktop` (must be full absolute paths!), then copy it:
+```
+cp qgis.desktop ~/.local/share/applications
 ```
 
 ## Usage
@@ -46,6 +51,8 @@ then
 docker rm <process id or container name>
 ```
 
+In case the launch script doesn't work properly, try adding the `-t` flag to the `docker run` command.
+This will break launching from the desktop environment though.
 
 ## Acknowledgements
 

--- a/qgis.desktop
+++ b/qgis.desktop
@@ -2,11 +2,11 @@
 [Desktop Entry]
 Name=QGIS 2.18 LTR in Docker
 GenericName=QGIS 2.18 LTR in Docker
-Comment=GIS 2.18 LTR in Docker
-Exec=~/Documents/launch_scripts/docker_qgis.sh %U
+Comment=QGIS 2.18 LTR in Docker
+Exec=/home/norwin/bin/qgis2 %U
 Terminal=false
 Type=Application
 StartupNotify=true
 MimeType=text/shp;
-Icon=/usr/local/qgis-icon-60x60.png
+Icon=/home/norwin/src/docker-qgis2/qgis-icon-60x60.png
 Categories=Science

--- a/qgis2
+++ b/qgis2
@@ -29,8 +29,8 @@ USER_NAME=`basename $HOME`
 # --rm will remove the container as soon as it ends
 
 
-sudo docker run --rm --name qgis2 \
-    -it \
+docker run --rm --name qgis2 \
+    -i \
     -v ${HOME}:/home/${USER_NAME} \
     -v /tmp/.X11-unix:/tmp/.X11-unix \
     -e DISPLAY=unix$DISPLAY \


### PR DESCRIPTION
Thanks for the docker image & the launch script!

Launching from gnome desktop was not working. Changes:

- `-t` flag in docker run prevents from running in non-interactive shell.
  Calls from an interactive shell are still working according to my tests.
- documented installation of `qgis.desktop` file
- `sudo docker` [is considered an antipattern](https://docs.docker.com/install/linux/linux-postinstall/#manage-docker-as-a-non-root-user)
